### PR TITLE
Add php zip dependency. 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,13 @@ RUN apt-get update && apt-get install -y libmagickwand-6.q16-dev --no-install-re
 && echo "extension=imagick.so" > /usr/local/etc/php/conf.d/ext-imagick.ini
 
 RUN apt-get update && apt-get install -y \
-    libmcrypt-dev
+    libmcrypt-dev \
+    zlib1g-dev
 
 RUN docker-php-ext-install pdo_mysql
 RUN docker-php-ext-install mbstring
 RUN docker-php-ext-install mcrypt
+RUN docker-php-ext-install zip
 
 RUN usermod -u 1000 www-data
 RUN usermod -G staff www-data


### PR DESCRIPTION
Hi, I'm using your craft-php container to play around with craftcms. 
Thanks for sharing :-) 

Today i've tried to update craft to the latest version (3.0.0beta.4) via `composer update`.
Then craft showed an error message to me, that i have to install the PHP ZIP Module to continue. 

After adding the needed ZIP Dependencies, i was able to continue the update process.


